### PR TITLE
Add games count functionality

### DIFF
--- a/pingpong.py
+++ b/pingpong.py
@@ -75,6 +75,8 @@ def index():
             JOIN player l ON loser = l.id
             ORDER BY date DESC LIMIT 10;''')
 
+    games = db.execute('SELECT Count(*) AS TotalMatches FROM match;').fetchone()
+
     # get or regenerate the schedule
     weekrow = db.execute('SELECT * FROM week;').fetchone();
     week = datetime.now().isocalendar()[1]
@@ -115,7 +117,7 @@ def index():
         qualities.append(ts.quality_1vs1(r1, r2) * 100)
 
     return render_template('index.html',
-            players=players, aliases=aliases, recents=recents,
+            players=players, aliases=aliases, recents=recents, games = games[0],
             schedule=zip(schedule, qualities), rankedweek=(week%2==1))
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -136,7 +136,7 @@ don't record it (but agree before the match!)
 
 <h1>Recent matches</h1>
 <p>
-View entire match history <a href="{{url_for('matches')}}">here</a>.
+{{games}} Matches have been recorded, view entire match history <a href="{{url_for('matches')}}">here</a>.
 <br/>
 Scheduled matches are highlighted in yellow.
 </p>


### PR DESCRIPTION
Using the very advanced SQLite function Count I am beginning to add the
total count of games recorded since the inception of the game. As a PM
there is nothing more important to me than understanding and tracking
where all my time goes and I think total ping pong games is a good
approximation.

This is a multi part change that will require other changes potentially
on the matches page as well and may include styling or position updates
after consulting with the ping pong PM.

In the future we might be able to add more advanced functionality like a
table of who plays the most games but will also need to consult the ping
pong PM to see if it's on the backlog.
